### PR TITLE
fix for chef-12.6.0 and version bump

### DIFF
--- a/bin/appbundle-updater
+++ b/bin/appbundle-updater
@@ -168,6 +168,12 @@ class Updater
     banner("Cleaning #{app} checkout")
     app_dir.rmtree if app_dir.directory?
 
+    top_dir = chefdk.join("embedded/apps")
+    unless File.exist?(top_dir)
+      banner("Creating #{top_dir} directory")
+      FileUtils.mkdir_p top_dir
+    end
+
     if ( tarball )
       # NOTE: THIS IS DELIBERATELY PURE RUBY USING NO NATIVE GEMS AND ONLY
       # THE RUBY STDLIB BY DESIGN

--- a/lib/appbundle_updater/version.rb
+++ b/lib/appbundle_updater/version.rb
@@ -1,3 +1,3 @@
 module AppbundleUpdater
-  VERSION = "0.2.6"
+  VERSION = "0.2.7"
 end


### PR DESCRIPTION
looks like 12.6.0 did away with the /opt/chef/emebedded/apps directory completely, so we need to build it ourselves to make a checkout there.   maybe we should move this somewhere else in the future, but for now lets just act the same way...