### PR TITLE
ohai definition needs development installed

### DIFF
--- a/bin/appbundle-updater
+++ b/bin/appbundle-updater
@@ -163,7 +163,7 @@ CHEFDK_APPS = [
   App.new(
     "ohai",
     "chef/ohai",
-    "test development",
+    "test",
     "#{bin_dir.join("rake")} install",
   ),
   App.new(


### PR DESCRIPTION
rake is in dev gems, so without development the subsequent
rake task will fail.

its possible development gems in ohai may need to get split up
