### PR TITLE
Add support for inspec

### DIFF
--- a/bin/appbundle-updater
+++ b/bin/appbundle-updater
@@ -161,6 +161,11 @@ CHEFDK_APPS = [
     "#{bin_dir.join("rake")} install",
   ),
   App.new(
+    "inspec",
+    "chef/inspec",
+    "test integration tools maintenance deploy",
+    "#{bin_dir.join("rake")} install"),
+  App.new(
     "ohai",
     "chef/ohai",
     "test",


### PR DESCRIPTION
InSpec is appbundled into the ChefDK. This change allows appbundle-updater
to update our users' InSpec installs in the ChefDK as needed.