### PR TITLE
Add the cookstyle app

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Updating various other softwares in /opt/chefdk bundle to master:
 ```
 sudo appbundle-updater chefdk berkshelf master
 sudo appbundle-updater chefdk chef-vault master
+sudo appbundle-updater chefdk cookstyle master
 sudo appbundle-updater chefdk ohai master
 sudo appbundle-updater chefdk foodcritic master
 sudo appbundle-updater chefdk test-kitchen master

--- a/bin/appbundle-updater
+++ b/bin/appbundle-updater
@@ -155,6 +155,12 @@ CHEFDK_APPS = [
     "#{bin_dir.join("rake")} install",
   ),
   App.new(
+     'cookstyle',
+     'chef/cookstyle',
+     nil,
+    "#{bin_dir.join("rake")} install",
+  ),
+  App.new(
     "foodcritic",
     "acrmp/foodcritic",
     nil,


### PR DESCRIPTION
Allows you to update cookstyle version.

Tested locally:

```
~ ❯❯❯ /opt/chefdk/embedded/bin/cookstyle --version
Cookstyle 1.3.0
  * RuboCop 0.47.1

~ ❯❯❯ sudo chef exec appbundle-updater chefdk cookstyle v1.4.0
-----> Cleaning cookstyle checkout
-----> Installing Packages
[2017-07-03T00:18:37+02:00] WARN: Ohai::Config[:log_level] is set. Ohai::Config[:log_level] is deprecated and will be removed in future releases of ohai. Use ohai.log_level in your configuration file to configure :log_level for ohai.
[2017-07-03T00:18:37+02:00] WARN: Ohai::Config[:log_location] is set. Ohai::Config[:log_location] is deprecated and will be removed in future releases of ohai. Use ohai.log_location in your configuration file to configure :log_location for ohai.
i do not know how to install compilers and git on this platform...
-----> Cloning cookstyle from https://github.com/chef/cookstyle.git
    running: git clone https://github.com/chef/cookstyle.git /opt/chefdk/embedded/apps/cookstyle
-----> Checking out cookstyle to v1.4.0
    running: git checkout v1.4.0
-----> Installing dependencies
    running: /opt/chefdk/embedded/bin/ruby /opt/chefdk/embedded/bin/bundle install
-----> Installing gem
    running: /opt/chefdk/embedded/bin/ruby /opt/chefdk/embedded/bin/bundle exec /opt/chefdk/embedded/bin/rake install
-----> Updating appbundler binstubs for cookstyle
    running: /opt/chefdk/embedded/bin/ruby /opt/chefdk/embedded/bin/appbundler /opt/chefdk/embedded/apps/cookstyle /opt/chefdk/bin
-----> Finished!

~ ❯❯❯ /opt/chefdk/embedded/bin/cookstyle --version
Cookstyle 1.4.0
  * RuboCop 0.47.1
```