### PR TITLE
fix pulling tags

### DIFF
--- a/bin/appbundle-updater
+++ b/bin/appbundle-updater
@@ -226,7 +226,7 @@ class Updater
           extract_tgz(tempfile.path)
         end
         base = File.basename repo
-        FileUtils.mv "#{base}-#{ref}".gsub(/\//, "-"), "#{app.name}"
+        FileUtils.mv Dir.glob("#{base}-*").gsub(/\//, "-"), "#{app.name}"
       end
     else
       git_url = "https://github.com/#{repo}.git"


### PR DESCRIPTION
we don't use the tag here, we have to know the version of the thing
we're pulling, but we don't know the version, so just use a glob
since there should be ever only one.
