### PR TITLE
Support Fedora 30 by trying to install both lzma-devel and xz-devel

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -27,7 +27,7 @@ steps:
       docker:
         image: ruby:2.6-stretch
 
-- label: un-lint-and-specs-windows
+- label: run-lint-and-specs-windows
   command:
     - bundle install --jobs=7 --retry=3 --without docs debug
     - bundle exec rake

--- a/bin/appbundle-updater
+++ b/bin/appbundle-updater
@@ -72,7 +72,9 @@ def install_package_dependencies
     run("apt-get -q -y install build-essential git liblzma-dev zlib1g-dev")
   when /fedora/, /rhel/, /amazon/
     if File.exist?("/usr/bin/dnf")
-      run("dnf -y install gcc gcc-c++ make git zlib-devel lzma-devel")
+      run("dnf -y install gcc gcc-c++ make git zlib-devel")
+      # lzma-devel has been replaced in fedora 30+ with xz-devel
+      run("dnf -y install lzma-devel || dnf -y install xz-devel")
     else
       run("yum -y install gcc gcc-c++ make git zlib-devel lzma-devel")
     end


### PR DESCRIPTION
Fedora 30 no longer includes lzma-devel and instead ships xz-devel. This is causing our travis chef/chef integration tests to fail.  DNF exits 1 if it can't find a package and it doesn't appear you can turn that off. Instead just try to install both and let bash sort it out. I'm open to a better solution, but parsing out version numbers isn't it since at some point amazon and rhel will adopt this same package change. We want it to just work when the distros do their thing.

Signed-off-by: Tim Smith <tsmith@chef.io>