### PR TITLE
Time to add chef-15 support

### DIFF
--- a/bin/appbundle-updater
+++ b/bin/appbundle-updater
@@ -119,7 +119,12 @@ def extract_tgz(file, destination = ".")
   end
 end
 
-App = Struct.new(:name, :repo, :bundle_without, :install_command) do
+App = Struct.new(:name, :repo, :bundle_without, :install_command, :gems) do
+  def initialize(*)
+    super
+    self.gems ||= {}
+  end
+
   def to_s
     name
   end
@@ -143,13 +148,34 @@ CHEFDK_APPS = [
     "chef",
     "chef/chef",
     "development docgen chefstyle",
-    chef_install_command
+    "#{bin_dir.join("bundle")} install --without server,docgen,maintenance,pry,travis,integration,ci,chefstyle",
+    {
+      "chef" => %w{server docgen maintenance pry travis integration ci chefstyle},
+      "chef-bin" => %w{server docgen maintenance pry travis integration ci chefstyle},
+      "ohai" =>  %w{server docgen maintenance pry travis integration ci chefstyle},
+      "inspec-core-bin" =>  %w{server docgen maintenance pry travis integration ci chefstyle},
+    },
   ),
   App.new(
     "chef-dk",
     "chef/chef-dk",
     "development test",
-    "#{bin_dir.join("rake")} install"
+    "#{bin_dir.join("bundle")} install",
+    {
+      "chef" => %w{docgen chefstyle omnibus_package},
+      "foodcritic" => %w{development test},
+      "test-kitchen" => %w{changelog debug docs development},
+      "inspec" =>  %w{deploy tools maintenance integration},
+      "chef-run" => %w{changelog docs debug},
+      "chef-cli" =>  %w{changelog docs debug},
+      "berkshelf" => %w{changelog docs debug development},
+      "chef-bin" => %w{changelog},
+      "chef-apply" => %w{changelog},
+      "chef-vault" => %w{changelog},
+      "ohai" => %w{changelog},
+      "opscode-pushy-client" => %w{changelog},
+      "cookstyle" => %w{changelog},
+    },
   ),
   App.new(
     "chef-vault",
@@ -190,7 +216,7 @@ CHEFDK_APPS = [
 ].freeze
 
 class Updater
-  attr_reader :app, :ref, :tarball, :repo
+  attr_reader :app, :ref, :tarball, :repo, :gems
 
   def initialize(options)
     @app = options[:app]
@@ -199,6 +225,7 @@ class Updater
     @extra_bin_files = options[:extra_bin_files]
     @binstubs_source = options[:binstubs_source]
     @repo = options[:repo] || @app.repo
+    @gems = @app.gems
   end
 
   def start
@@ -258,11 +285,23 @@ class Updater
     end
 
     banner("Updating appbundler binstubs for #{app}")
-    Dir.chdir(app_dir) do
-      cmd = "#{bin_dir.join("appbundler")} #{app_dir} #{chefdk.join("bin")}"
-      cmd += " --extra-bin-files #{@extra_bin_files}" if @extra_bin_files
-      cmd += " --binstubs-source #{@binstubs_source}" if @binstubs_source
-      ruby(cmd)
+    if gems.empty?
+      Dir.chdir(app_dir) do
+        cmd = "#{bin_dir.join("appbundler")} #{app_dir} #{chefdk.join("bin")}"
+        cmd += " --extra-bin-files #{@extra_bin_files}" if @extra_bin_files
+        cmd += " --binstubs-source #{@binstubs_source}" if @binstubs_source
+        ruby(cmd)
+      end
+    else
+      gems.each do |gem_name, without|
+        Dir.chdir(app_dir) do
+          cmd = "#{bin_dir.join("appbundler")} #{app_dir} #{chefdk.join("bin")} #{gem_name}"
+          cmd += " --without #{@without.join(",")}" if @without
+          cmd += " --extra-bin-files #{@extra_bin_files}" if @extra_bin_files
+          cmd += " --binstubs-source #{@binstubs_source}" if @binstubs_source
+          ruby(cmd)
+        end
+      end
     end
 
     banner("Finished!")


### PR DESCRIPTION
Use the 3 arg version of appbundler to correctly appbundle the
binstubs out of the chef-bin gem.  Should also fix appbundle-updater
for ChefDK >= 2.0 but I haven't fully tested that one.

This may necessarily drop support for chef <= 14 so bumping the major