### PR TITLE
Just use `rake install` on windows

### DIFF
--- a/bin/appbundle-updater
+++ b/bin/appbundle-updater
@@ -130,12 +130,7 @@ App = Struct.new(:name, :repo, :bundle_without, :install_commands, :gems) do
   end
 end
 
-chef_install_command =
-  if windows?
-    "#{bin_dir.join("gem")} build chef-windows.gemspec & #{bin_dir.join("gem")} install chef*.gem --no-document"
-  else
-    "#{bin_dir.join("bundle")} exec #{bin_dir.join("rake")} install"
-  end
+chef_install_command = "#{bin_dir.join("bundle")} exec #{bin_dir.join("rake")} install"
 
 CHEFDK_APPS = [
   App.new(


### PR DESCRIPTION
Pretty sure this works because this is what we use in omnibus to do
builds now (and has to be done to get chef-bin and chef-utils correct)
