### PR TITLE
Add support for post bundle install hook

### DIFF
--- a/bin/appbundle-updater
+++ b/bin/appbundle-updater
@@ -274,6 +274,11 @@ class Updater
       ruby(cmd)
     end
 
+    banner("Re-installing git-installed gems")
+    Dir.chdir(app_dir) do
+      ruby("post-bundle-install.rb #{chefdk}") if File.exist?("#{app_dir}/post-bundle-install.rb")
+    end
+
     banner("Installing gem")
     Dir.chdir(app_dir) do
       Array(install_commands).each do |command|


### PR DESCRIPTION
Create a `post-bundle-install.rb` file and it runs in between the bundle install and the rake install.

Useful for going through the git installed gems and installing them properly into the ruby library.