### PR TITLE
Remove push jobs and foodcritic

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@
 
 **Pull Request [Response Time Maximum](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md)**: 14 days
 
-Helper to update Chef and Chef-DK appbundle'd apps inside of an omnibus bundle.
+Helper to update Chef and Chef Workstation appbundle'd apps inside of an omnibus bundle.
 
 ## Requirements
 
-* A Chef Workstation, ChefDK, or Chef Client installation in the standard location.
+* A Chef Workstation or Chef Client installation in the standard location.
 * You need to have the `git` command in your PATH.
 
 ## Usage Examples

--- a/bin/appbundle-updater
+++ b/bin/appbundle-updater
@@ -157,7 +157,6 @@ CHEFDK_APPS = [
     "#{bin_dir.join("bundle")} install",
     {
       "chef" => %w{docgen chefstyle omnibus_package},
-      "foodcritic" => %w{development test},
       "test-kitchen" => %w{changelog debug docs development},
       "inspec" =>  %w{deploy tools maintenance integration},
       "chef-run" => %w{changelog docs debug},
@@ -167,7 +166,6 @@ CHEFDK_APPS = [
       "chef-apply" => %w{changelog},
       "chef-vault" => %w{changelog},
       "ohai" => %w{changelog},
-      "opscode-pushy-client" => %w{changelog},
       "cookstyle" => %w{changelog},
     }
   ),
@@ -181,12 +179,6 @@ CHEFDK_APPS = [
     "cookstyle",
     "chef/cookstyle",
     "development debug docs",
-    "#{bin_dir.join("rake")} install"
-  ),
-  App.new(
-    "foodcritic",
-    "foodcritic/foodcritic",
-    "development",
     "#{bin_dir.join("rake")} install"
   ),
   App.new(


### PR DESCRIPTION
These are both EOL. Let them die.

Signed-off-by: Tim Smith <tsmith@chef.io>