### PR TITLE
remove bundle exec from rake install

### DIFF
--- a/bin/appbundle-updater
+++ b/bin/appbundle-updater
@@ -129,7 +129,7 @@ App = Struct.new(:name, :repo, :bundle_without, :install_commands, :gems) do
   end
 end
 
-chef_install_command = "#{bin_dir.join("bundle")} exec #{bin_dir.join("rake")} install"
+chef_install_command = "#{bin_dir.join("rake")} install"
 
 CHEFDK_APPS = [
   App.new(


### PR DESCRIPTION
This seems to be necessary to remove this now to work around
our monorepo setup on windows.

Since we already bundle install and we should be upgrading this
shouldn't break anything afaik.
