### PR TITLE
Need a version bump for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ If you don't want "master" you can use any other git tag/branch/sha/etc that git
 
 ## Using a GitHub Fork
 
-By default this gem clones from the official repos from the software.  To override and point
+By default this gem clones from the official repos from the software. To override and point
 at at fork use the `--github`` option on the command-line:
 
 ```ruby


### PR DESCRIPTION
I'm a bit confused how we just version bumped to 1.0.23 which we
released back in March, we need a 1.0.24
