### PR TITLE
Use rake install:local

### DIFF
--- a/bin/appbundle-updater
+++ b/bin/appbundle-updater
@@ -129,7 +129,7 @@ App = Struct.new(:name, :repo, :bundle_without, :install_commands, :gems) do
   end
 end
 
-chef_install_command = "#{bin_dir.join("rake")} install"
+chef_install_command = "#{bin_dir.join("rake")} install:local"
 
 CHEFDK_APPS = [
   App.new(


### PR DESCRIPTION
We have all our deps installed from the bundle install so
use `rake install:local` to not do any rubygems depsolving.

For some reason this seems to fix the case when the main
branch has been advanced and we do not have a new major version
yet published to rubygems.

Which may be a rubygems bug?

At any rate it matches what we do in omnibus builds.