### PR TITLE
Delimit rc and version no as rc.1 in gemspec as using 'rc1' has not pushed the gem to artifactory

### DIFF
--- a/appbundle-updater.gemspec
+++ b/appbundle-updater.gemspec
@@ -4,7 +4,7 @@ require "appbundle_updater/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "appbundle-updater"
-  spec.version       = "#{AppbundleUpdater::VERSION}.rc1"
+  spec.version       = "#{AppbundleUpdater::VERSION}.rc.1"
   spec.authors       = ["lamont-granquist"]
   spec.email         = ["lamont@chef.io"]
   spec.description   = %q{Updates appbundled apps in Chef's omnibus packages}


### PR DESCRIPTION


<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This is trial 2 of tagging this gem as `rc`. Previously we tried https://github.com/chef/appbundle-updater/pull/115 but that has not pushed the gem artifactory. Here trying out if delimiting `rc` from version no `1` makes it work.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
