### PR TITLE
Skip inspec-core-bin for 19

### DIFF
--- a/bin/appbundle-updater
+++ b/bin/appbundle-updater
@@ -147,7 +147,7 @@ CHEFDK_APPS = [
       "chef" => %w{docgen chefstyle},
       "chef-bin" => %w{development},
       "ohai" =>  %w{development docs debug profile},
-      "inspec-core-bin" =>  %w{development},
+      # "inspec-core-bin" => %w{development}, # <== temporary? for RC version
     }
   ),
   App.new(


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Chef 19 RC2 is using git spec'ed inspec gems, which causes trouble for appbundler/appbundle-updater with a gem that's in a glob path is used. 
In addition, the `inspec-core-bin` gem is not required for non-omnibus builds, so `inspec-core-bin` may be permanently removed.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
