### PR TITLE
Use bundler binary from ruby package instead of from vendor/gems as it's no longer there

### DIFF
--- a/bin/appbundle-updater
+++ b/bin/appbundle-updater
@@ -203,6 +203,11 @@ HABITAT_PACKAGES = [
   ),
 ].freeze
 
+def bundler_from_ruby_pkg
+  ruby_path = `hab pkg path #{ruby_pkg}`.strip
+  File.join(ruby_path, "bin", "bundle")
+end
+
 class Updater
   attr_reader :app, :ref, :tarball, :origin, :repo, :gems, :install_commands
 
@@ -260,7 +265,10 @@ class Updater
 
       banner("Installing dependencies")
       Dir.chdir(app_dir) do
-        cmd = "#{vendor_bin_dir.join("bundle")} install"
+        # Use the bundler from Ruby package instead of from vendor/bin
+        bundle_executable = bundler_from_ruby_pkg
+        banner("Using bundler from Ruby package: #{bundle_executable}")
+        cmd = "#{bundle_executable} install"
         cmd += " --without #{app.bundle_without}" if app.bundle_without
         ruby(cmd)
       end


### PR DESCRIPTION
The latest habitat package from Infra client 19 no longer has bundler binary in `vendor/gems` so the kitchen tests GHA flow using test-kitchen-enterprise fails at bundle install stage when applying the commit SHA. So here update the code so as to use bundler from packaged ruby

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
